### PR TITLE
Improve dev UX with proper function arglists

### DIFF
--- a/src/spade/core.cljc
+++ b/src/spade/core.cljc
@@ -100,8 +100,8 @@
       :global :static
       :keyframes :no-args
       (cond
-        (every? symbol? params) :default
         (some #{'&} params) :variadic
+        (every? symbol? params) :default
         :else :destructured))))
 (defmethod declare-style :static
   [mode class-name _ factory-name-var factory-fn-name]

--- a/test/spade/core_test.cljs
+++ b/test/spade/core_test.cljs
@@ -151,5 +151,5 @@
            (destructured {:c "blue" :b "red"}))))
 
   (testing "Don't barf on Variadic args"
-    (is (= "spade-core-test-variadic_bluegreen"
-           (variadic "blue" "green")))))
+    (is (= "spade-core-test-variadic_cyanmagentayellow"
+           (variadic "cyan" "magenta" "yellow")))))


### PR DESCRIPTION
As mentioned in the comments, we don't seem to be able to generate good arglists if your factory has variadic args, but I suspect this is an uncommon case. In the common case of a simple args vector we can use the original vector directly, which reduces the amount of code generated; and in the less-common case where destructuring is used for a fixed number of args we can still generate a nice `:arglists` meta that hides the implementation details.

Fixes #2 