### PR TITLE
Experiment: add special syntax for CSS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,59 @@ appropriate CSS into the DOM on-demand, and returns the animation identifier:
   {:animation [[(anim-frames) "560ms" 'ease-in-out]]})
 ```
 
+### Syntactic Sugar
+
+Spade also provides some extra syntactic sugar, performed at compile time
+for "zero-cost" abstractions.
+
+#### CSS Custom Properties
+
+CSS custom properties (AKA variables) can be a convenient way to, for
+example, define dynamic theme colors once and reuse them throughout the
+codebase. Spade provides some extra sugar to make using them feel more
+idiomatic:
+
+```clojure
+(defglobal light-dark
+  (at-media {:prefers-color-scheme 'dark}
+    [":root" {:theme/*background* "#000"
+              :theme/*text* "#E0EBFF"}])
+  [":root" {:theme/*background* "#fff"
+            :theme/*text* "#000"}])
+
+(defclass page []
+  {:background :theme/*background*
+   :color :theme/*text*})
+```
+
+Notice how our declaration and usage sites are identical, and that
+they're "just" normal keywords. However, by using `*earmuffs*` around
+the name of the keyword, Spade knows that it is meant to be a variable,
+and applies the correct CSS styling based on the position within the
+style. Normal keyword namespace semantics apply, so you can expect that
+`:theme/*text*` and `:crew.quarters/*text*` will result in distinct
+variables.
+
+The above example will generate the following CSS:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme--background: #000;
+    --theme--text: #E0EBFF;
+  }
+}
+
+:root {
+  --theme--background: #fff;
+  --theme--text: #000;
+}
+
+.page {
+  background: var(--theme--background);
+  color: var(--theme--text);
+}
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ The above example will generate the following CSS:
 }
 ```
 
+Note that [CSS Custom Properties are not supported on all browsers][4], and this syntax compiles to that feature directly without any attempt at backwards compatibility—if CSS Custom Properties are not supported on a browser you are targetting, this syntax will also not be supported.
+
 ## Development
 
 To get an interactive development environment run:
@@ -231,3 +233,4 @@ Distributed under the Eclipse Public License either version 1.0
 [1]: https://github.com/css-modules/css-modules
 [2]: https://github.com/noprompt/garden/
 [3]: https://github.com/roosta/herb
+[4]: https://caniuse.com/css-variables

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ for "zero-cost" abstractions.
 
 CSS custom properties (AKA variables) can be a convenient way to, for
 example, define dynamic theme colors once and reuse them throughout the
-codebase. Spade provides some extra sugar to make using them feel more
-idiomatic:
+codebase. Spade provides some extra sugar to make using them easier and
+more idiomatic:
 
 ```clojure
 (defglobal light-dark
@@ -176,9 +176,15 @@ Notice how our declaration and usage sites are identical, and that
 they're "just" normal keywords. However, by using `*earmuffs*` around
 the name of the keyword, Spade knows that it is meant to be a variable,
 and applies the correct CSS styling based on the position within the
-style. Normal keyword namespace semantics apply, so you can expect that
+style. This naming was chosen because it is reminiscent of the naming
+of dynamic Clojure vars, and because `*` is not valid in a CSS property
+name, so the meaning is unambiguous.
+
+Normal keyword namespace semantics apply, so you can expect that
 `:theme/*text*` and `:crew.quarters/*text*` will result in distinct
-variables.
+variables. In fact, you don't need any namespace at all; `:*text*` will
+also result in a perfectly valid CSS variable, disinct from any of the
+other two mentioned above.
 
 The above example will generate the following CSS:
 

--- a/dev/spade/demo.cljs
+++ b/dev/spade/demo.cljs
@@ -12,7 +12,7 @@
   ["100%" {:opacity end}])
 
 (defglobal background
-  [:body {:var/my-var "22pt"
+  [:body {:*my-var* "22pt"
           :background "#333"}])
 
 (defglobal text
@@ -23,7 +23,7 @@
     {:padding "80px"})
   {:padding "8px"}
 
-  [:.title {:font-size :var/my-var
+  [:.title {:font-size :*my-var*
             :animation [[(parameterized-anim-frames 0 0.5) "560ms" 'ease-in-out]]}])
 
 (defclass colorized-with-key [color]

--- a/dev/spade/demo.cljs
+++ b/dev/spade/demo.cljs
@@ -12,7 +12,8 @@
   ["100%" {:opacity end}])
 
 (defglobal background
-  [:body {:background "#333"}])
+  [:body {:var/my-var "22pt"
+          :background "#333"}])
 
 (defglobal text
   [:body {:color "#fff"}])
@@ -22,7 +23,7 @@
     {:padding "80px"})
   {:padding "8px"}
 
-  [:.title {:font-size "22pt"
+  [:.title {:font-size :var/my-var
             :animation [[(parameterized-anim-frames 0 0.5) "560ms" 'ease-in-out]]}])
 
 (defclass colorized-with-key [color]

--- a/src/spade/core.cljc
+++ b/src/spade/core.cljc
@@ -1,6 +1,6 @@
 (ns spade.core
   (:require [clojure.string :as str]
-            [clojure.walk :refer [postwalk]]
+            [clojure.walk :refer [postwalk prewalk]]
             [spade.util :refer [factory->name build-style-name]]))
 
 (defn- extract-key [style]
@@ -58,9 +58,10 @@
   `(spade.runtime/->css-var ~(varify-key element)))
 
 (defn- rename-vars [style]
-  (postwalk
+  (prewalk
     (fn [element]
-      (if (map-entry? element)
+      (cond
+        (map-entry? element)
         (let [var-key? (css-var? (key element))
               var-val? (css-var? (val element))]
           (if (or var-key? var-val?)
@@ -70,6 +71,10 @@
 
             element))
 
+        (css-var? element)
+        (varify-val element)
+
+        :else
         element))
     style))
 

--- a/src/spade/runtime.cljs
+++ b/src/spade/runtime.cljs
@@ -1,6 +1,7 @@
 (ns spade.runtime
   (:require [clojure.string :as str]
-            [garden.core :as garden]))
+            [garden.core :as garden]
+            [garden.types :refer [->CSSFunction]]))
 
 (defonce
   ^{:private true
@@ -9,6 +10,9 @@
 
 (defonce ^:dynamic *css-compile-flags*
   {:pretty-print? goog.DEBUG})
+
+(defn ->css-var [n]
+  (->CSSFunction "var" n))
 
 (defn compile-css [elements]
   (garden/css *css-compile-flags* elements))

--- a/test/spade/core_test.cljs
+++ b/test/spade/core_test.cljs
@@ -190,7 +190,15 @@
     (is (= ["spade-core-test-computed-key_BLUE"
             "spade-core-test-composed-attrs_blue"
             "spade-core-test-compose-ception"]
-           (str/split (compose-ception) #" ")))))
+           (str/split (compose-ception) #" ")))
+
+    (let [generated (:css (composed-attrs-factory$ "" ["blue"] "blue"))]
+      (is (false? (str/includes? generated
+                                 "color:")))
+      (is (false? (str/includes? generated
+                                 "composes:")))
+      (is (true? (str/includes? generated
+                                "background:"))))))
 
 (defclass destructured [{:keys [c b]}]
   ^{:key (str c "_" b)}

--- a/test/spade/core_test.cljs
+++ b/test/spade/core_test.cljs
@@ -30,7 +30,8 @@
   {:*my-var* "42pt"
    ::*namespaced* "blue"
    :font-size :*my-var*
-   :background ::*namespaced*})
+   :background ::*namespaced*
+   :color [[:*my-var* :!important]]})
 
 (deftest defclass-test
   (testing "computed-key test"
@@ -55,7 +56,7 @@
                  ".with-media { background: blue; } "
                  ".with-media .nested { background: red; }")))))
 
-  (testing "CSS var declaration and  usage"
+  (testing "CSS var declaration and usage"
     (let [generated (-> (class-with-vars-factory$ "class-with-vars" [])
                         :css
                         (str/replace #"\s+" " "))]
@@ -66,6 +67,7 @@
                  " --spade-core-test--namespaced: blue;"
                  " font-size: var(--my-var);"
                  " background: var(--spade-core-test--namespaced);"
+                 " color: var(--my-var) !important;"
                  " }"))))))
 
 
@@ -159,15 +161,7 @@
     (is (= ["spade-core-test-computed-key_BLUE"
             "spade-core-test-composed-attrs_blue"
             "spade-core-test-compose-ception"]
-           (str/split (compose-ception) #" ")))
-
-    (let [generated (:css (composed-attrs-factory$ "" ["blue"] "blue"))]
-      (is (false? (str/includes? generated
-                                 "color:")))
-      (is (false? (str/includes? generated
-                                 "composes:")))
-      (is (true? (str/includes? generated
-                                "background:"))))))
+           (str/split (compose-ception) #" ")))))
 
 (defclass destructured [{:keys [c b]}]
   ^{:key (str c "_" b)}

--- a/test/spade/core_test.cljs
+++ b/test/spade/core_test.cljs
@@ -6,8 +6,10 @@
 ; for the linter's sake:
 (declare with-media-factory$
          class-with-vars-factory$
+         fixed-style-attrs-factory$
          composed-factory$
-         composed-attrs-factory$)
+         composed-attrs-factory$
+         parameterized-key-frames-factory$)
 
 (defclass computed-key [color]
   ^{:key (str/upper-case color)}
@@ -72,16 +74,29 @@
 
 
 (defattrs fixed-style-attrs []
-  {:color "blue"})
+  {:*my-var* "blue"
+   :color :*my-var*})
 
 (deftest defattrs-test
   (testing "Return map from defattrs"
     (is (= {:class "spade-core-test-fixed-style-attrs"}
-           (fixed-style-attrs)))))
+           (fixed-style-attrs))))
+
+  (testing "CSS var declaration and usage"
+    (let [generated (-> (fixed-style-attrs-factory$ "with-vars" [])
+                        :css
+                        (str/replace #"\s+" " "))]
+      (is (str/includes?
+            generated
+            (str ".with-vars {"
+                 " --my-var: blue;"
+                 " color: var(--my-var);"
+                 " }"))))))
 
 
 (defglobal global-1
-  [:body {:background "blue"}])
+  [":root" {:*background* "blue"}]
+  [:body {:background :*background*}])
 
 (defglobal global-2
   (at-media {:min-width "42px"}
@@ -90,7 +105,8 @@
 (deftest defglobal-test
   (testing "Declare const var with style from global"
     (is (string? global-1))
-    (is (= "body {\n  background: blue;\n}"
+    (is (= (str ":root {\n  --background: blue;\n}\n\n"
+                "body {\n  background: var(--background);\n}")
            global-1)))
 
   (testing "Support at-media automatically"
@@ -103,7 +119,8 @@
   [:from {:opacity 0}])
 
 (defkeyframes parameterized-key-frames [from]
-  [:from {:opacity from}])
+  [:from {::*from* from
+          :opacity ::*from*}])
 
 (deftest defkeyframes-test
   (testing "Return keyframes name from defkeyframes"
@@ -114,7 +131,19 @@
   (testing "Return dynamic keyframes name from parameterized defkeyframes"
     (is (fn? key-frames))
     (is (= (str "spade-core-test-parameterized-key-frames_" (hash [0]))
-           (parameterized-key-frames 0)))))
+           (parameterized-key-frames 0))))
+
+  (testing "CSS var declaration and usage"
+    (let [generated (-> (parameterized-key-frames-factory$
+                          "with-vars" [42] 42)
+                        :css
+                        (str/replace #"\s+" " "))]
+      (is (str/includes?
+            generated
+            (str "from {"
+                 " --spade-core-test--from: 42;"
+                 " opacity: var(--spade-core-test--from);"
+                 " }"))))))
 
 (defclass composed [color]
   ^{:key color}


### PR DESCRIPTION
At compile time, keywords whose names are surrounded in `*ear-muffs*` get transformed to refer to CSS variables. When used as a map key, `:*font-size*` becomes `:--font-size`, and `:my.namespace/*font-size*` becomes `:--my-namespace--font-size`. Keywords used as map values get transformed the same, but are additionally wrapped by `spade.runtime/->css-var`, which results in garden transforming it to eg `var(--my-namespace--font-size)`. The advantage of this approach compared to the original one (see below) is that any var usage creates just a single keyword object, instead of two, that can be reused throughout the compiled code.

This is basically compile-time syntactic sugar for people wanting to use CSS variables in a way a somewhat idiomatic way.

TODO:
- [x] Handle keywords not in map-value position (for example, within vectors)

---

*Original description*:

At compile time, keywords with the namespace "var" get transformed
to refer to CSS variables. Map keys like `:var/font-size` become
`:--font-size` and map values become `:var(font-size)`. This syntax
seems nice since, at least in the "resolve" version, it *looks like*
the equivalent CSS.

However, this syntax means that all vars are global, unnamespaced, which
is perhaps not ideal. So, this is sort of a proof of concept. Perhaps a
better syntax would be eg `::*font-size*`. This is somewhat familiar due
to clojure's use of earmuffs for dynamic vars, and also allows
namespacing with native clojure namespaces. "Global" vars if desired
could still be created as eg `:global/*font-size*`.
