### PR TITLE
Optimize for the common case

### DIFF
--- a/src/spade/container.cljc
+++ b/src/spade/container.cljc
@@ -3,6 +3,12 @@
 (defprotocol IStyleContainer
   "The IStyleContainer represents anything that can be used by Spade to
    'mount' styles for access by Spade style components."
+  (mounted-info
+    [this style-name]
+    "Given a style-name, return the info object that was passed when style-name
+     was mounted, or nil if that style is not currently mounted.")
   (mount-style!
-    [this style-name css]
-    "Ensure the style with the given name and CSS is available"))
+    [this style-name css info]
+    "Ensure the style with the given name and CSS is available. [info]
+     should be stored somewhere in-memory to be quickly retrieved
+     by a call to [mounted-info]."))

--- a/src/spade/container/alternate.cljc
+++ b/src/spade/container/alternate.cljc
@@ -5,8 +5,13 @@
 
 (deftype AlternateStyleContainer [get-preferred fallback]
   IStyleContainer
-  (mount-style!
-    [_ style-name css]
+  (mounted-info
+    [_ style-name]
     (or (when-let [preferred (get-preferred)]
-          (sc/mount-style! preferred style-name css))
-        (sc/mount-style! fallback style-name css))))
+          (sc/mounted-info preferred style-name))
+        (sc/mounted-info fallback style-name)))
+  (mount-style!
+    [_ style-name css info]
+    (or (when-let [preferred (get-preferred)]
+          (sc/mount-style! preferred style-name css info))
+        (sc/mount-style! fallback style-name css info))))

--- a/src/spade/container/atom.cljc
+++ b/src/spade/container/atom.cljc
@@ -2,8 +2,15 @@
   "The AtomStyleContainer renders styles into an atom it is provided with."
   (:require [spade.container :refer [IStyleContainer]]))
 
-(deftype AtomStyleContainer [styles-atom]
+(deftype AtomStyleContainer [styles-atom info-atom]
   IStyleContainer
-  (mount-style! [_ style-name css]
-    (swap! styles-atom assoc style-name css)))
+  (mounted-info [_ style-name]
+    (get @info-atom style-name))
+  (mount-style! [_ style-name css info]
+    (swap! styles-atom assoc style-name css)
+    (swap! info-atom assoc style-name info)))
 
+(defn create-container
+  ([] (create-container (atom nil)))
+  ([styles-atom] (create-container styles-atom (atom nil)))
+  ([styles-atom info-atom] (->AtomStyleContainer styles-atom info-atom)))

--- a/src/spade/container/dom.cljs
+++ b/src/spade/container/dom.cljs
@@ -10,18 +10,19 @@
 (defn- perform-update! [obj css]
   (set! (.-innerHTML (:element obj)) css))
 
-(defn update! [styles-container id css]
+(defn update! [styles-container id css info]
   (swap! styles-container update id
          (fn update-injected-style [obj]
            (when-not (= (:source obj) css)
              (perform-update! obj css))
-           (assoc obj :source css))))
+           (assoc obj :source css :info info))))
 
-(defn inject! [target-dom styles-container id css]
+(defn inject! [target-dom styles-container id css info]
   (let [element (doto (js/document.createElement "style")
                   (.setAttribute "spade-id" (str id)))
         obj {:element element
              :source css
+             :info info
              :id id}]
     (assert (some? target-dom)
             "An <head> element or target DOM is required to inject the style.")
@@ -33,17 +34,22 @@
 
 (deftype DomStyleContainer [target-dom styles]
   IStyleContainer
-  (mount-style! [_ style-name css]
+  (mounted-info [_ style-name]
+    (let [resolved-container (or styles
+                                 *injected-styles*)]
+      (:info (get @resolved-container style-name))))
+
+  (mount-style! [_ style-name css info]
     (let [resolved-container (or styles
                                  *injected-styles*)]
       (if (contains? @resolved-container style-name)
-        (update! resolved-container style-name css)
+        (update! resolved-container style-name css info)
 
         (let [resolved-dom (or (when (ifn? target-dom)
                                  (target-dom))
                                target-dom
                                (.-head js/document))]
-          (inject! resolved-dom resolved-container style-name css))))))
+          (inject! resolved-dom resolved-container style-name css info))))))
 
 (defn create-container
   "Create a DomStyleContainer. With no args, the default is created, which

--- a/src/spade/core.cljc
+++ b/src/spade/core.cljc
@@ -153,25 +153,25 @@
   (let [[composition style] (extract-composes style)
         style-var (gensym "style")
         style (->> style prefix-at-media rename-vars)
-        [base-style-var name-var key-var name-let] (build-style-naming-let
-                                                     style params style-name-var)
+        [base-style-var name-var key-var style-naming-let] (build-style-naming-let
+                                                             style params style-name-var)
         style-decl (if base-style-var
                      `(into [(str "." ~name-var)] ~base-style-var)
                      (into [`(str "." ~name-var)] style))]
-    `(let ~(vec (concat name-let
+    `(let ~(vec (concat style-naming-let
                         [style-var style-decl]))
        ~(with-composition composition name-var key-var style-var))))
 
 (defn- transform-keyframes-style [style params style-name-var]
   (let [style (->> style prefix-at-media rename-vars)
-        [style-var name-var key-var style-naming-let] (build-style-naming-let
-                                                        style params style-name-var)
+        [base-style-var name-var key-var style-naming-let] (build-style-naming-let
+                                                             style params style-name-var)
         info-map (cond->
                    `{:css (when ~name-var
                             (spade.runtime/compile-css
                               (garden.stylesheet/at-keyframes
                                 ~name-var
-                                ~(or style-var (vec style)))))
+                                ~(or base-style-var (vec style)))))
                      :name ~name-var}
 
                    key-var (assoc ::key key-var))]

--- a/src/spade/core.cljc
+++ b/src/spade/core.cljc
@@ -10,22 +10,24 @@
   (:key (meta (first style))))
 
 (defn- find-key-meta [style]
-  (::key
-    (postwalk
-      (fn [form]
-        (if (and (map? form)
-                 (::key form))
-          form
+  (->> style
 
-          (if-let [k (:key (meta form))]
-            {::key k}
+       (postwalk
+         (fn [form]
+           (if (and (map? form)
+                    (::key form))
+             form
 
-            (if-let [k (when (seq? form)
-                         (some ::key form))]
-              {::key k}
+             (if-let [k (:key (meta form))]
+               {::key k}
 
-              form))))
-      style)))
+               (if-let [k (when (sequential? form)
+                            (some ::key form))]
+                 {::key k}
+
+                 form)))))
+
+       ::key))
 
 (def ^:private auto-imported-at-form?
   #{'at-font-face
@@ -112,7 +114,6 @@
   [style params name-var]
   (let [has-key-meta? (some? (find-key-meta style))
         static-key (extract-key style)
-
         key-var (gensym "key")]
     (cond
       ; easiest case: no params? no need to call build-style-name

--- a/src/spade/core.cljc
+++ b/src/spade/core.cljc
@@ -207,7 +207,7 @@
     (some? (find-key-meta style))
     `(clojure.core/memoize
        (fn [params#]
-         (let [dry-run# (apply ~factory-fn-name nil params# params#)]
+         (let [dry-run# (~factory-fn-name nil params#)]
            (#'build-style-name
              ~factory-name-var
              (::key dry-run#)
@@ -294,11 +294,13 @@
 
         style-name-var (gensym "style-name")
         params-var (gensym "params")
-        factory-params (vec (concat [style-name-var params-var] params))
         factory-name-var (gensym "factory-name")]
     `(do
-       (defn ~factory-fn-name ~factory-params
-         ~(transform-style mode style params style-name-var))
+       (defn ~factory-fn-name [~style-name-var ~params-var]
+         ~(if params
+            `(let [~params ~params-var]
+               ~(transform-style mode style params style-name-var))
+            (transform-style mode style nil style-name-var)))
 
        (let [~factory-name-var (factory->name
                                  (macros/case

--- a/src/spade/core.cljc
+++ b/src/spade/core.cljc
@@ -231,6 +231,7 @@
   [mode class-name _ name-fn-name factory-fn-name]
   `(def ~class-name (spade.runtime/ensure-style!
                       ~mode
+                      (meta (var ~class-name))
                       ~name-fn-name
                       ~factory-fn-name
                       nil)))
@@ -239,6 +240,7 @@
   `(defn ~class-name []
      (spade.runtime/ensure-style!
        ~mode
+       (meta (var ~class-name))
        ~name-fn-name
        ~factory-fn-name
        nil)))
@@ -255,6 +257,7 @@
        ~raw-params
        (spade.runtime/ensure-style!
          ~mode
+         (meta (var ~class-name))
          ~name-fn-name
          ~factory-fn-name
          ~raw-params))))
@@ -266,6 +269,7 @@
   `(defn ~class-name [& params#]
      (spade.runtime/ensure-style!
        ~mode
+       (meta (var ~class-name))
        ~name-fn-name
        ~factory-fn-name
        params#)))
@@ -275,6 +279,7 @@
   `(defn ~class-name ~params
      (spade.runtime/ensure-style!
        ~mode
+       (meta (var ~class-name))
        ~name-fn-name
        ~factory-fn-name
        ~params)))

--- a/src/spade/core.cljc
+++ b/src/spade/core.cljc
@@ -123,7 +123,8 @@
       (not has-key-meta?)
       [nil name-var nil nil]
 
-      ; TODO can we use static-key? that might be nice
+      ; okay case: a (nearly) static key that we can pull out and compute
+      ; directly, without building the rest of the style form
       static-key
       [nil name-var key-var
        `[~key-var ~static-key]]

--- a/src/spade/core.cljc
+++ b/src/spade/core.cljc
@@ -204,14 +204,13 @@
     ; but since this is memoized (and :key isn't much used anyway) this is
     ; probably not a big deal for now. Would be a nice optimization, however.
     (some? (find-key-meta style))
-    `(;clojure.core/memoize
-       do
+    `(clojure.core/memoize
        (fn [params#]
-         (let [key# (::key (apply ~factory-fn-name nil params# params#))]
-           (println key#)
+         (let [dry-run# (apply ~factory-fn-name nil params# params#)]
            (#'build-style-name
              ~factory-name-var
-             key#))))
+             (::key dry-run#)
+             params#))))
 
     :else
     `(clojure.core/memoize

--- a/src/spade/runtime.cljc
+++ b/src/spade/runtime.cljc
@@ -43,13 +43,15 @@
                             :value item})))))
          (str/join " "))))
 
-(defn ensure-style! [mode name-factory style-factory params]
+(defn ensure-style! [mode metadata name-factory style-factory params]
   (let [style-name (name-factory params)
+        always-compile? (or (:always-compile-css metadata)
+                            (:always-compile-css? *css-compile-flags*))
 
         ; NOTE: If we've been instructed to always compile css, then always
         ; assume it's unmounted.
         ; TODO: support adding this flag as meta on the class, too.
-        mounted-info (when-not (:always-compile-css? *css-compile-flags*)
+        mounted-info (when-not always-compile?
                        ; TODO: Does this require a re-compile?
                        nil)
 

--- a/src/spade/runtime.cljc
+++ b/src/spade/runtime.cljc
@@ -50,13 +50,13 @@
 
         ; NOTE: If we've been instructed to always compile css, then always
         ; assume it's unmounted.
-        ; TODO: support adding this flag as meta on the class, too.
         mounted-info (when-not always-compile?
                        ; TODO: Does this require a re-compile?
                        nil)
 
         {css :css :as info} (or
                               mounted-info
+                              ; TODO Refactor macro to avoid needing to apply
                               (apply style-factory style-name params params))]
 
     (when-not mounted-info

--- a/src/spade/runtime.cljc
+++ b/src/spade/runtime.cljc
@@ -43,8 +43,9 @@
                             :value item})))))
          (str/join " "))))
 
-(defn ensure-style! [mode base-style-name factory params]
-  (let [{css :css style-name :name :as info} (apply factory base-style-name params params)]
+(defn ensure-style! [mode name-factory style-factory params]
+  (let [style-name (name-factory params)
+        {css :css :as info} (apply style-factory style-name params params)]
 
     (sc/mount-style! *style-container* style-name css)
 

--- a/src/spade/runtime.cljc
+++ b/src/spade/runtime.cljc
@@ -45,9 +45,16 @@
 
 (defn ensure-style! [mode name-factory style-factory params]
   (let [style-name (name-factory params)
-        {css :css :as info} (apply style-factory style-name params params)]
 
-    (sc/mount-style! *style-container* style-name css)
+        ; TODO: Does this require a re-compile?
+        mounted-info nil
+
+        {css :css :as info} (or
+                              mounted-info
+                              (apply style-factory style-name params params))]
+
+    (when-not mounted-info
+      (sc/mount-style! *style-container* style-name css))
 
     (case mode
       :attrs {:class (compose-names info)}

--- a/src/spade/runtime.cljc
+++ b/src/spade/runtime.cljc
@@ -7,7 +7,9 @@
 
 (defonce ^:dynamic *css-compile-flags*
   {:pretty-print? #? (:cljs goog.DEBUG
-                      :clj false)})
+                      :clj false)
+   :always-compile-css? #? (:cljs goog.DEBUG
+                            :clj false)})
 
 (defonce ^:dynamic *style-container* (defaults/create-container))
 

--- a/src/spade/runtime.cljc
+++ b/src/spade/runtime.cljc
@@ -46,8 +46,12 @@
 (defn ensure-style! [mode name-factory style-factory params]
   (let [style-name (name-factory params)
 
-        ; TODO: Does this require a re-compile?
-        mounted-info nil
+        ; NOTE: If we've been instructed to always compile css, then always
+        ; assume it's unmounted.
+        ; TODO: support adding this flag as meta on the class, too.
+        mounted-info (when-not (:always-compile-css? *css-compile-flags*)
+                       ; TODO: Does this require a re-compile?
+                       nil)
 
         {css :css :as info} (or
                               mounted-info

--- a/src/spade/runtime.cljc
+++ b/src/spade/runtime.cljc
@@ -56,8 +56,8 @@
         {css :css :as info} (or
                               mounted-info
 
-                              ; TODO Refactor macro to avoid needing to apply
-                              (apply style-factory style-name params params))]
+                              ; Not mounted *or* we always want to compile
+                              (style-factory style-name params))]
 
     (when-not mounted-info
       (sc/mount-style! *style-container* style-name css info))

--- a/src/spade/runtime.cljc
+++ b/src/spade/runtime.cljc
@@ -49,18 +49,18 @@
                             (:always-compile-css? *css-compile-flags*))
 
         ; NOTE: If we've been instructed to always compile css, then always
-        ; assume it's unmounted.
+        ; assume it's unmounted. The container can update a mounted style
         mounted-info (when-not always-compile?
-                       ; TODO: Does this require a re-compile?
-                       nil)
+                       (sc/mounted-info *style-container* style-name))
 
         {css :css :as info} (or
                               mounted-info
+
                               ; TODO Refactor macro to avoid needing to apply
                               (apply style-factory style-name params params))]
 
     (when-not mounted-info
-      (sc/mount-style! *style-container* style-name css))
+      (sc/mount-style! *style-container* style-name css info))
 
     (case mode
       :attrs {:class (compose-names info)}

--- a/src/spade/runtime/defaults.clj
+++ b/src/spade/runtime/defaults.clj
@@ -1,7 +1,8 @@
 (ns spade.runtime.defaults
-  (:require [spade.container.atom :refer [->AtomStyleContainer]]))
+  (:require [spade.container.atom :as atom-container]))
 
 (defonce shared-styles-atom (atom nil))
+(defonce shared-styles-info-atom (atom nil))
 
 (defn create-container []
-  (->AtomStyleContainer shared-styles-atom))
+  (atom-container/create-container shared-styles-atom shared-styles-info-atom))

--- a/test/spade/core_test.cljs
+++ b/test/spade/core_test.cljs
@@ -154,6 +154,11 @@
    :background color})
 
 (deftest defclass-compose-test
+  (testing "Composing should not break :key naming"
+    (let [generated (composed-factory$ "" ["blue"])]
+      (= "blue"
+          (:spade.core/key generated))))
+
   (testing "computed-key test"
     (is (= "spade-core-test-computed-key_BLUE spade-core-test-composed_blue"
            (composed "blue")))

--- a/test/spade/core_test.cljs
+++ b/test/spade/core_test.cljs
@@ -138,7 +138,7 @@
 
   (testing "CSS var declaration and usage"
     (let [generated (-> (parameterized-key-frames-factory$
-                          "with-vars" [42] 42)
+                          "with-vars" [42])
                         :css
                         (str/replace #"\s+" " "))]
       (is (str/includes?
@@ -158,7 +158,7 @@
     (is (= "spade-core-test-computed-key_BLUE spade-core-test-composed_blue"
            (composed "blue")))
 
-    (let [generated (:css (composed-factory$ "" ["blue"] "blue"))]
+    (let [generated (:css (composed-factory$ "" ["blue"]))]
       (is (false? (str/includes? generated
                                  "color:")))
       (is (false? (str/includes? generated
@@ -179,7 +179,7 @@
            (-> (composed-list "blue")
                (str/split #" "))))
 
-    (let [generated (:css (composed-list-factory$ "" ["blue"] "blue"))]
+    (let [generated (:css (composed-list-factory$ "" ["blue"]))]
       (is (false? (str/includes? generated
                                 "color:")))
       (is (false? (str/includes? generated
@@ -202,7 +202,7 @@
     (is (= "spade-core-test-computed-key_BLUE spade-core-test-composed-attrs_blue"
            (:class (composed-attrs "blue"))))
 
-    (let [generated (:css (composed-attrs-factory$ "" ["blue"] "blue"))]
+    (let [generated (:css (composed-attrs-factory$ "" ["blue"]))]
       (is (false? (str/includes? generated
                                  "color:")))
       (is (false? (str/includes? generated
@@ -216,7 +216,7 @@
             "spade-core-test-compose-ception"]
            (str/split (compose-ception) #" ")))
 
-    (let [generated (:css (composed-attrs-factory$ "" ["blue"] "blue"))]
+    (let [generated (:css (composed-attrs-factory$ "" ["blue"]))]
       (is (false? (str/includes? generated
                                  "color:")))
       (is (false? (str/includes? generated

--- a/test/spade/jvm_test.clj
+++ b/test/spade/jvm_test.clj
@@ -1,6 +1,6 @@
 (ns spade.jvm-test
   (:require [clojure.test :refer [deftest is testing]]
-            [spade.container.atom :refer [->AtomStyleContainer]]
+            [spade.container.atom :as atom-container]
             [spade.core :refer [defclass with-styles-container]]))
 
 (defclass blue-class []
@@ -9,10 +9,9 @@
 (deftest with-styles-container-test
   (testing "Render styles to dynamically-provided Atom container"
     (let [styles (atom nil)
-          container (->AtomStyleContainer styles)
+          container (atom-container/create-container styles)
           style-name (with-styles-container container
                        (blue-class))]
       (is (= "blue-class" style-name))
       (is (= ".blue-class{color:blue}"
              (get @styles style-name))))))
-


### PR DESCRIPTION
This PR implements the proposals in #10 to optimize for the common case of referentially-transparent style factory functions. I was able to keep the manual `:key` support by updating style factories to skip CSS compilation when `nil` is passed as the style name. In addition, style factories no longer have to be invoked with `apply`, passing params as a vector and then individually after; we just unpack the params vector via a `let` in the generated code.

There are some breaking changes to the StyleContainer protocol, but I would imagine that is a fairly transparent change to most clients.

- Generate a memoized function for computing a style's name
- Use the newly-generated naming fn; improve manual :key support
- Clean up
- Prepare to only conditionally compile CSS, update DOM
- Respect global :always-compile-css?
- Add support for :always-compile-css per-function escape hatch
- Clean up some TODOs
- Change StyleContainer to support skipping compile when mounted
- Invoke style-factory directly, without `apply`
