### PR TITLE
Migrate to a newer version of garden

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.10.520"]
-                 [garden "1.3.10"]
+                 [com.lambdaisland/garden "1.5.569"]
                  [net.cgrand/macrovich "0.2.1"]]
 
   :plugins [[lein-figwheel "0.5.19"]

--- a/src/spade/util.cljc
+++ b/src/spade/util.cljc
@@ -49,3 +49,18 @@
 
     ; easiest case: no key is necessary
     :else base))
+
+(defn unpack-keyframes-nesting
+  "In the latest versions of garden, using [:&] to return multiple
+   style rules from within a conditional or other structure like
+   `(let)` in an `(at-keyframes)` structure keeps that `&` in the
+   output CSS. This function 'unpacks' such structures so the compiled CSS is clean."
+  [style-rules]
+  (mapcat
+   (fn maybe-unpack-keyframes-nesting [style-rule]
+     (if (and (vector? style-rule)
+              (= :& (first style-rule)))
+       (next style-rule)
+       [style-rule]))
+   style-rules))
+


### PR DESCRIPTION
This version of garden is [maintained by lambdaisland][1], and includes a bunch of fixes---including finally getting rid of that annoying compile warning about `abs`. However, it did break defkeyframes (see my discussion about what's going on in #20), so this PR additionally tweaks our usage of the underlying `(at-keyframes)` function to avoid introducing any breaking changes.

[1]: https://github.com/lambdaisland/garden
